### PR TITLE
Make the endpoint for the Tidbyt API configurable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     },
     "features": {
       "ghcr.io/devcontainers/features/go:1": {
-          "version": "1.23.3"
+          "version": "1.23.6"
       }
     },
     "customizations": {

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.3"
+          go-version: "1.23.6"
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y install libwebp-dev

--- a/TidbytAssistant/CHANGELOG.md
+++ b/TidbytAssistant/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 1.0.15 
+## 1.0.16
+
+- The base URL used to push rendered images to a server is now configurable. This can be used to switch from Tidbyt's server to API-compatible alternatives like https://github.com/tavdog/tronbyt-server.
+
+## 1.0.15
+
 - Fix filename used in legacy code path for single-file apps.
 
 ## 1.0.14

--- a/TidbytAssistant/Dockerfile
+++ b/TidbytAssistant/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=homeassistant/amd64-base:latest
 FROM ${BUILD_FROM} AS builder
 
 # Args from build.yaml
-ARG GO_VERSION=1.23.4
+ARG GO_VERSION=1.23.6
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 

--- a/TidbytAssistant/Dockerfile
+++ b/TidbytAssistant/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=homeassistant/amd64-base:latest
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.21
 
 FROM ${BUILD_FROM} AS builder
 

--- a/TidbytAssistant/build.yaml
+++ b/TidbytAssistant/build.yaml
@@ -1,2 +1,2 @@
 args:
-  GO_VERSION: "1.23.4"
+  GO_VERSION: "1.23.6"

--- a/TidbytAssistant/config.yaml
+++ b/TidbytAssistant/config.yaml
@@ -1,6 +1,6 @@
 name: "TidbytAssistant"
 description: "Add-on with Pixlet application. Allows you to push custom apps to your Tidbyt. Install with integration v1.0.13"
-version: "1.0.15"
+version: "1.0.16"
 slug: "tidbytassistant"
 url: "https://github.com/savdagod/ha-addons/tree/main/TidbytAssistant"
 init: False

--- a/TidbytAssistant/config.yaml
+++ b/TidbytAssistant/config.yaml
@@ -13,5 +13,8 @@ ports_description:
   9000/tcp: Web Server
 map:
   - type: homeassistant_config
+options:
+  base_url: "https://api.tidbyt.com"
 schema:
   log_level: list(debug|info|warning|error)?
+  base_url: url

--- a/TidbytAssistant/docker-compose.yml
+++ b/TidbytAssistant/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        - BUILD_FROM=homeassistant/amd64-base:latest
+        - BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.21
         - GO_VERSION=1.23.6
     ports:
       - 9000:9000

--- a/TidbytAssistant/docker-compose.yml
+++ b/TidbytAssistant/docker-compose.yml
@@ -5,6 +5,6 @@ services:
       context: .
       args:
         - BUILD_FROM=homeassistant/amd64-base:latest
-        - GO_VERSION=1.23.4
+        - GO_VERSION=1.23.6
     ports:
       - 9000:9000

--- a/TidbytAssistant/go.mod
+++ b/TidbytAssistant/go.mod
@@ -1,6 +1,6 @@
 module github.com/savdagod/ha-addons/TidbytAssistant
 
-go 1.23.4
+go 1.23.6
 
 require tidbyt.dev/pixlet v0.34.0
 

--- a/TidbytAssistant/main.go
+++ b/TidbytAssistant/main.go
@@ -23,16 +23,16 @@ import (
 )
 
 var (
-	cache     = runtime.NewInMemoryCache()
-	healthURL = flag.String("health", "", "perform health check for the given URL and exit")
-	appCache  = map[string]*runtime.Applet{}
+	tidbytBaseURL = "https://api.tidbyt.com"
+	cache         = runtime.NewInMemoryCache()
+	healthURL     = flag.String("health", "", "perform health check for the given URL and exit")
+	appCache      = map[string]*runtime.Applet{}
 
 	errUnknownContentType = errors.New("unknown content type")
 	errInvalidFileName    = errors.New("invalid file name")
 )
 
 const (
-	tidbytBaseURL = "https://api.tidbyt.com"
 	silenceOutput = false
 	renderGif     = false
 	timeout       = 30 * time.Second
@@ -58,6 +58,7 @@ type (
 
 	options struct {
 		LogLevel string `json:"log_level"`
+		BaseURL  string `json:"base_url"`
 	}
 )
 
@@ -294,6 +295,8 @@ func parseOptions() {
 		slog.Error(fmt.Sprintf("error parsing /data/options: %v", err))
 		return
 	}
+
+	tidbytBaseURL = opt.BaseURL
 
 	switch opt.LogLevel {
 	case "debug":

--- a/TidbytAssistant/main.go
+++ b/TidbytAssistant/main.go
@@ -48,6 +48,7 @@ type (
 		PublishType    string            `json:"publishtype"`
 		ContentType    string            `json:"contenttype"`
 		Arguments      map[string]string `json:"starargs"`
+		BaseURL        string            `json:"base_url"`
 	}
 
 	tidbytPushRequest struct {
@@ -73,7 +74,11 @@ func pushHandler(w http.ResponseWriter, req *http.Request) {
 	slog.Debug(fmt.Sprintf("Received push request %+v", r))
 
 	background := r.PublishType == "background"
-	if err := pushApp(r.ContentType, r.Content, r.Arguments, r.DeviceID, r.InstallationID, r.Token, background); err != nil {
+	baseURL := r.BaseURL
+	if baseURL == "" {
+		baseURL = tidbytBaseURL
+	}
+	if err := pushApp(baseURL, r.ContentType, r.Content, r.Arguments, r.DeviceID, r.InstallationID, r.Token, background); err != nil {
 		handleHTTPError(w, err)
 	}
 }
@@ -109,7 +114,7 @@ func handleHTTPError(w http.ResponseWriter, err error) {
 	http.Error(w, err.Error(), status)
 }
 
-func pushApp(contentType, contentName string, arguments map[string]string, deviceID, installationID, token string, background bool) error {
+func pushApp(baseURL, contentType, contentName string, arguments map[string]string, deviceID, installationID, token string, background bool) error {
 	var rootDir string
 	cache := false
 	switch contentType {
@@ -132,7 +137,7 @@ func pushApp(contentType, contentName string, arguments map[string]string, devic
 		return fmt.Errorf("failed to render app: %v", err)
 	}
 
-	if err := tidbytPush(image, deviceID, installationID, token, background); err != nil {
+	if err := tidbytPush(baseURL, image, deviceID, installationID, token, background); err != nil {
 		return fmt.Errorf("failed to push image: %v", err)
 	}
 
@@ -141,7 +146,7 @@ func pushApp(contentType, contentName string, arguments map[string]string, devic
 	return nil
 }
 
-func tidbytPush(imageData []byte, deviceID, installationID, apiToken string, background bool) error {
+func tidbytPush(baseURL string, imageData []byte, deviceID, installationID, apiToken string, background bool) error {
 	payload, err := json.Marshal(
 		tidbytPushRequest{
 			Image:          base64.StdEncoding.EncodeToString(imageData),
@@ -152,7 +157,7 @@ func tidbytPush(imageData []byte, deviceID, installationID, apiToken string, bac
 	if err != nil {
 		return fmt.Errorf("failed to marshal json: %w", err)
 	}
-	u := fmt.Sprintf("%s/v0/devices/%s/push", tidbytBaseURL, url.PathEscape(deviceID))
+	u := fmt.Sprintf("%s/v0/devices/%s/push", baseURL, url.PathEscape(deviceID))
 	if err := tidbytAPI(u, "POST", payload, apiToken); err != nil {
 		return fmt.Errorf("failed to push image: %w", err)
 	}


### PR DESCRIPTION
This allows using other endpoints like a local Tronbyt server instead of Tidbyt's server.